### PR TITLE
카데고리 중복 선택

### DIFF
--- a/src/components/CategoryCard.jsx
+++ b/src/components/CategoryCard.jsx
@@ -1,17 +1,16 @@
 import '../scss/components/CategoryCard.scss'
 
 import React from 'react'
-import { Link } from 'react-router-dom'
 
 const CategoryCard = props => {
   const { card } = props
   return (
-    <Link to={`/categories/${card.id}`}>
+    <div className="card">
       <div className="card-item">
         <h3 className="card-item__title">{card.title}</h3>
         <p className="card-item__text">문제 수: {card.count}</p>
       </div>
-    </Link>
+    </div>
   )
 }
 

--- a/src/routes/Categories.jsx
+++ b/src/routes/Categories.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import { Container, Input, Row, Col, Button } from 'reactstrap'
 import '../scss/components/Categories.scss'
 
@@ -28,10 +28,38 @@ const Categories = props => {
     setData(fetchCategoryData)
   }, [])
 
+  //카데고리 중복 선택
+  const [choiceCategories, setChoiceCategories] = useState([]) //선택한 카데고리가 담긴 배열: 카데고리의 id가 들어있음.
+
+  const choiceMulitleCategories = useCallback(
+    e => {
+      const currentChoicedId = e.currentTarget.id
+      e.currentTarget.classList.toggle('choice')
+
+      if (choiceCategories.includes(currentChoicedId)) {
+        //이미 선택한 카데고리를 고르면 배열에서 삭제함 (토글 기능)
+        setChoiceCategories(prev => [
+          ...prev.filter(
+            el => el.toUpperCase() !== currentChoicedId.toUpperCase()
+          )
+        ])
+      } else {
+        setChoiceCategories(prev => [...prev, currentChoicedId])
+      }
+    },
+    [choiceCategories]
+  )
+
   // 카테고리 카드 생성 -> 컴포넌트로 나눌까 생각중
   const categories = data.map(card => (
-    <Col key={card.id} sm={6} xs={6}>
-      <CategoryCard card={card} />
+    <Col
+      key={card.id}
+      sm={6}
+      xs={6}
+      id={card.id}
+      onClickCapture={choiceMulitleCategories}
+    >
+      <CategoryCard card={card} id={card.id} />
     </Col>
   ))
 

--- a/src/routes/Categories.jsx
+++ b/src/routes/Categories.jsx
@@ -57,7 +57,7 @@ const Categories = props => {
       sm={6}
       xs={6}
       id={card.id}
-      onClickCapture={choiceMulitleCategories}
+      onClick={choiceMulitleCategories}
     >
       <CategoryCard card={card} id={card.id} />
     </Col>

--- a/src/routes/Categories.jsx
+++ b/src/routes/Categories.jsx
@@ -59,7 +59,7 @@ const Categories = props => {
       id={card.id}
       onClick={choiceMulitleCategories}
     >
-      <CategoryCard card={card} id={card.id} />
+      <CategoryCard card={card} />
     </Col>
   ))
 

--- a/src/scss/components/CategoryCard.scss
+++ b/src/scss/components/CategoryCard.scss
@@ -30,7 +30,16 @@
     // }
 
     .col-sm-6 {
-      a {
+      &.choice {
+        /*카테고리 선택시 배경색이 붉은 색으로 변함*/
+        .card {
+          .card-item {
+            background: #f57b51;
+          }
+        }
+      }
+
+      .card {
         display: block;
         margin-bottom: 1.5rem;
         text-decoration: none;


### PR DESCRIPTION
기존에는 카테고리를 선택하면 바로 다른 페이지로 이동하도록 구현되어있었습니다.

바뀐 로직에서는 카테고리를 선택하면 카드의 색이 바뀌고
Categories.jsx의 choiceCategories라는 배열에 지금 고른 카테고리에 해당되는 id값이 저장됩니다.
토글 기능으로 구현되어 한번 더 클릭하면 배열에서 id값이 삭제됩니다.

Categories.jsx말고 CategoryCard.jsx에서 구현하면 코드가 분산되어 좀 더 깔끔하고 짧게 짤 수 있었을텐데
문제 개수 설정도 어차피 Categories.jsx에서 구현할 것 같고 고른 카테고리랑 문제 개수를 한번에 요청에 담아서 보내야하는거라
일단은 choiceCategories를 구하는 로직을 Categories.jsx에서 구현했습니다.
개인적으로는 지금 Categories.jsx가 100줄이 넘어가서 분리 한 번 했으면 합니다..