### PR TITLE
[Feat] 메인 페이지 레이아웃 구조 설계

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "bootstrap": "^5.1.3",
         "boxicons": "^2.0.9",
         "dayjs": "^1.10.7",
+        "faker": "^5.5.3",
         "immer": "^9.0.7",
         "prop-types": "^15.7.2",
         "react": "^17.0.2",
@@ -5202,6 +5203,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "node_modules/faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -13624,6 +13630,11 @@
           "dev": true
         }
       }
+    },
+    "faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bootstrap": "^5.1.3",
     "boxicons": "^2.0.9",
     "dayjs": "^1.10.7",
+    "faker": "^5.5.3",
     "immer": "^9.0.7",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",

--- a/src/components/TheFooter.jsx
+++ b/src/components/TheFooter.jsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { Button } from 'reactstrap'
+import Home from '../routes/Home'
+import Profile from '../routes/Profile'
+import Setting from '../routes/Setting'
+
+const TheFooter = () => {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        height: '66px',
+        padding: '4px 20px 8px 20px',
+        backgroundColor: '#fff'
+      }}
+    >
+      <Link
+        to="/"
+        component={<Home />}
+        style={{ textDecoration: 'none', padding: '6px 12px' }}
+      >
+        <i
+          className="bx bx-home"
+          style={{ fontSize: '25px', fontWeight: '400', color: '#5b5b5b' }}
+        ></i>
+      </Link>
+      <Button style={{ backgroundColor: 'transparent', border: 'none' }}>
+        <i
+          className="bx bx-search-alt"
+          style={{ fontSize: '25px', fontWeight: '400', color: '#5b5b5b' }}
+        ></i>
+      </Button>
+      <Link
+        to="/users"
+        component={<Profile />}
+        style={{ textDecoration: 'none', padding: '6px 12px' }}
+      >
+        <i
+          className="bx bx-user"
+          style={{ fontSize: '25px', fontWeight: '400', color: '#5b5b5b' }}
+        ></i>
+      </Link>
+      <Link
+        to="/config"
+        component={<Setting />}
+        style={{ textDecoration: 'none', padding: '6px 12px' }}
+      >
+        <i
+          className="bx bx-cog"
+          style={{ fontSize: '25px', fontWeight: '400', color: '#5b5b5b' }}
+        ></i>
+      </Link>
+    </div>
+  )
+}
+
+export default TheFooter

--- a/src/components/TheHeader.jsx
+++ b/src/components/TheHeader.jsx
@@ -22,30 +22,30 @@ const TheHeader = () => {
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
+        height: '50px',
         padding: '0 10px',
         backgroundColor: '#fff'
       }}
     >
-      <Link
-        to="/"
-        component={<Home />}
-        style={{ color: 'black', textDecoration: 'none' }}
+      <Button
+        color=""
+        onClick={clickBtn}
+        outline
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center'
+        }}
       >
-        <i
-          className="bx bxs-home"
-          style={{ fontSize: '25px', fontWeight: '900' }}
-        ></i>
-      </Link>
-      <Button color="" onClick={clickBtn} outline>
         {isOpen ? (
           <i
             className="bx bx-menu-alt-right"
-            style={{ fontSize: '30px', fontWeight: '900' }}
+            style={{ fontSize: '24px', fontWeight: '900' }}
           ></i>
         ) : (
           <i
             className="bx bx-menu"
-            style={{ fontSize: '30px', fontWeight: '900' }}
+            style={{ fontSize: '24px', fontWeight: '900' }}
           ></i>
         )}
       </Button>
@@ -101,6 +101,18 @@ const TheHeader = () => {
           </ListGroup>
         </OffcanvasBody>
       </Offcanvas>
+
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <i
+          className="bx bx-medal"
+          style={{ fontSize: '16px', fontWeight: '100', color: '#007866' }}
+        ></i>
+        <strong
+          style={{ fontSize: '14px', fontWeight: '400', margin: '0 10px' }}
+        >
+          Aiki
+        </strong>
+      </div>
     </div>
   )
 }

--- a/src/reducers/career.js
+++ b/src/reducers/career.js
@@ -1,5 +1,6 @@
+import produce from 'immer'
 export const initialState = {
-  careers = []
+  careers: []
 }
 
 const careerDummy = {
@@ -7,8 +8,8 @@ const careerDummy = {
   careerTitle: '직업군 이름'
 }
 
-const reducer = (state = initialState,action) => {
-  return produce(state, (draft) => {
+const reducer = (state = initialState, action) => {
+  return produce(state, draft => {
     switch (action.type) {
       default:
         return draft

--- a/src/reducers/categoryReducer.js
+++ b/src/reducers/categoryReducer.js
@@ -1,0 +1,48 @@
+const initial = {
+  categories: [
+    {
+      id: 1,
+      title: '복습하기',
+      count: 23,
+      tag: ['All', 'Front-End', 'Back-End']
+    },
+    {
+      id: 2,
+      title: '네트워크',
+      count: 23,
+      tag: ['All', 'Front-End', 'Back-End']
+    },
+    {
+      id: 3,
+      title: 'React',
+      count: 23,
+      tag: ['All', 'Front-End']
+    },
+    {
+      id: 4,
+      title: '공통 질문',
+      count: 23,
+      tag: ['All', 'Front-End', 'Back-End']
+    },
+    {
+      id: 5,
+      title: 'JavaScript',
+      count: 23,
+      tag: ['All', 'Front-End']
+    },
+    {
+      id: 6,
+      title: 'Node Express',
+      count: 23,
+      tag: ['All', 'Back-End']
+    }
+  ]
+}
+const categoryReducer = (state = initial, action) => {
+  switch (action.type) {
+    default:
+      return state
+  }
+}
+
+export default categoryReducer

--- a/src/reducers/collection.js
+++ b/src/reducers/collection.js
@@ -1,3 +1,4 @@
+import produce from 'immer'
 const initialState = {
   collections: []
 }

--- a/src/reducers/post.js
+++ b/src/reducers/post.js
@@ -1,3 +1,4 @@
+import produce from 'immer'
 const initialState = {
   mainPost: []
 }

--- a/src/reducers/postCategory.js
+++ b/src/reducers/postCategory.js
@@ -1,3 +1,4 @@
+import produce from 'immer'
 const initialState = {
   postCategories: []
 }

--- a/src/reducers/report.js
+++ b/src/reducers/report.js
@@ -1,3 +1,4 @@
+import produce from 'immer'
 const initialState = {
   reports: []
 }

--- a/src/reducers/reportCategory.js
+++ b/src/reducers/reportCategory.js
@@ -1,20 +1,20 @@
+import produce from 'immer'
 const initialState = {
-  reportCategories = []
+  reportCategories: []
 }
-
 
 const reportCategoryDummy = {
   reportCategoryId: '리포트 카데고리 아이디',
   reportCategoryTitle: '리포트 카데고리중 1개'
 }
 
-const reducer = (state = initialState,action) => {
-  return produce(state, (draft) => {
+const reducer = (state = initialState, action) => {
+  return produce(state, draft => {
     switch (action.type) {
       default:
         return draft
     }
   })
 }
-  
+
 export default reducer

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -9,6 +9,7 @@ import reportCategory from './reportCategory'
 import test from './test'
 import testCategory from './testCategory'
 import user from './user'
+import categoryReducer from './categoryReducer'
 
 const rootReducer = combineReducers({
   career,
@@ -19,7 +20,8 @@ const rootReducer = combineReducers({
   reportCategory,
   test,
   testCategory,
-  user
+  user,
+  categoryReducer
 })
 
 export default rootReducer

--- a/src/reducers/test.js
+++ b/src/reducers/test.js
@@ -1,5 +1,6 @@
+import produce from 'immer'
 const initialState = {
-    tests = []
+  tests: []
 }
 
 const testDummy = {
@@ -12,10 +13,10 @@ const testDummy = {
   answer: '답안'
 }
 
-const reducer = (state = initialState,action) => {
-  return produce(state, (draft) => {
+const reducer = (state = initialState, action) => {
+  return produce(state, draft => {
     switch (action.type) {
-    	default:
+      default:
         return draft
     }
   })

--- a/src/reducers/testCategory.js
+++ b/src/reducers/testCategory.js
@@ -1,19 +1,20 @@
+import produce from 'immer'
 const initialState = {
-  testCategoies = []
+  testCategoies: []
 }
 
 const testCategoryDummy = {
   testCategoryId: '테스트 카테고리 아이디',
-  testTitle: '테스트 이름',
+  testTitle: '테스트 이름'
 }
 
-const reducer = (state = initialState,action) => {
-  return produce(state, (draft) => {
+const reducer = (state = initialState, action) => {
+  return produce(state, draft => {
     switch (action.type) {
       default:
         return draft
     }
   })
 }
-  
+
 export default reducer

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -1,3 +1,4 @@
+import produce from 'immer'
 const initialState = {
   me: {}
 }

--- a/src/routes/Categories.jsx
+++ b/src/routes/Categories.jsx
@@ -16,7 +16,7 @@ const Categories = props => {
   // 가변 데이터
   const [data, setData] = useState([])
   // tag data
-  const fetchCareerTagData = useSelector(state => state.careerTagReducer.tags)
+  const fetchCareerTagData = useSelector(state => state.career.careers)
   // 검색어
   const [query, setQuery] = useState('')
   // search form on/off
@@ -125,11 +125,10 @@ const Categories = props => {
   const careerTagsView = fetchCareerTagData.map((tag, idx) => (
     <Button
       key={idx}
-      color={tag.color}
       className="career-card"
       onClick={e => selectTag(e.target.textContent)}
     >
-      {tag.title}
+      {tag.careerTitle}
     </Button>
   ))
 

--- a/src/routes/Home.jsx
+++ b/src/routes/Home.jsx
@@ -1,26 +1,94 @@
-import { Routes, Route, Link } from 'react-router-dom'
-import Categories from './Categories'
-import { Container, Button, Row } from 'reactstrap'
-import '../scss/components/Home.scss'
+import { Container, Button, Row, Col } from 'reactstrap'
 import React, { useCallback } from 'react'
 import TheButton from '../components/TheButton'
 import Login from './Login'
 
-const Home = ({ title, isLogged, LoggedState }) => {
+const Home = ({ isLogged, LoggedState }) => {
   const onLogOut = useCallback(() => {
     LoggedState(false)
   }, [isLogged])
   return (
     <Container>
-      <h1>{title}</h1>
       <Row>
-        <div className="content">
-          <Link to="Home">
-            <button className="ring-button">면접대비 바로 시작해보기!</button>
-          </Link>
-          {/* <Link to="AddQuestion">내 질문 등록하기</Link> */}
-        </div>
-        <Categories />
+        <Col style={{ textAlign: 'center' }}>
+          <div style={{ border: '1px solid red' }}>
+            <h3>Today Hot topic</h3>
+            <span>더 많은 토픽들을 확인하고 싶으세요?</span>
+            <div>
+              <h4>NAVER 필수 면접 문제</h4>
+              <span>우리 회사에 왜 지원하셨어요?</span>
+              <Button
+                style={{
+                  borderRadius: '20px',
+                  backgroundColor: '#c05562',
+                  border: 'none',
+                  fontSize: '14px',
+                  padding: '8px 16px'
+                }}
+              >
+                지금 확인하기
+              </Button>
+            </div>
+          </div>
+        </Col>
+      </Row>
+
+      <hr />
+
+      <Row>
+        <Col>
+          <div style={{ border: '1px solid red' }}>
+            <h3>Recent</h3>
+            <div style={{ textAlign: 'center' }}>
+              <h4>NAVER 필수 면접 문제</h4>
+              <span>12 solved / 25</span>
+              {/* Slide 로 넘기기 */}
+            </div>
+          </div>
+        </Col>
+      </Row>
+
+      <br />
+
+      <Row>
+        <Col>
+          <div style={{ border: '1px solid red' }}>
+            <h3>All Catogories</h3>
+            <div style={{ textAlign: 'center' }}>
+              <h4>All Random</h4>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-evenly',
+                  alignItems: 'center'
+                }}
+              >
+                <Button
+                  style={{
+                    borderRadius: '20px',
+                    backgroundColor: '#c05562',
+                    border: 'none',
+                    fontSize: '14px',
+                    padding: '8px 16px'
+                  }}
+                >
+                  Start Now
+                </Button>
+                <Button
+                  style={{
+                    borderRadius: '20px',
+                    backgroundColor: '#3186c4',
+                    border: 'none',
+                    fontSize: '14px',
+                    padding: '8px 16px'
+                  }}
+                >
+                  Pick Up
+                </Button>
+              </div>
+            </div>
+          </div>
+        </Col>
       </Row>
     </Container>
   )

--- a/src/routes/Profile.jsx
+++ b/src/routes/Profile.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Profile = () => {
+  return <div>user profile</div>
+}
+
+export default Profile

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -11,6 +11,9 @@ import Interview from './Interview'
 import Login from './Login'
 import SignUp from './SignUp'
 import TheHeader from '../components/TheHeader'
+import TheFooter from '../components/TheFooter'
+import Profile from './Profile'
+import Setting from './Setting'
 
 const Router = () => {
   const [isLogged, setIsLogged] = useState(false)
@@ -27,13 +30,7 @@ const Router = () => {
       <Routes>
         <Route
           path="/"
-          element={
-            <Home
-              title="면접 도우미"
-              isLogged={isLogged}
-              LoggedState={LoggedState}
-            />
-          }
+          element={<Home isLogged={isLogged} LoggedState={LoggedState} />}
         />
         <Route path="/question/add" element={<AddQuestion />} />
         <Route path="/categories" element={<Categories />} />
@@ -41,12 +38,15 @@ const Router = () => {
         <Route path="/interview" element={<Interview />} />
         <Route path="/question/answer" element={<ResultCheck />} />
         <Route path="/question/detail/:id" element={<QuestionDetail />} />
+        <Route path="/users" element={<Profile />} />
         <Route
           path="/users/login"
           element={<Login isLogged={isLogged} LoggedState={LoggedState} />}
         />
         <Route path="/users/signup" element={<SignUp />}></Route>
+        <Route path="/config" element={<Setting />} />
       </Routes>
+      <TheFooter />
     </BrowserRouter>
   )
 }

--- a/src/routes/Setting.jsx
+++ b/src/routes/Setting.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Setting = () => {
+  return <div>settings</div>
+}
+
+export default Setting


### PR DESCRIPTION
## 메인 페이지 레이아웃 구조 설계

### 헤더 
- 홈 버튼 Footer로 이동
- 메뉴버튼 좌측으로 이동
- 우측에 유저 정보 위치

### 메인 컨텐츠 영역
FIgma 시안을 토대로 작성
- Today hot topic 
- Recent
- All categories
- etc theme 들은 나중에 데이터로 불러와서 뿌리기

### 푸터 
- 홈, 검색, 프로필, 설정 으로 영역 구성